### PR TITLE
Add Transaction.result_dict to access result data

### DIFF
--- a/dps/models.py
+++ b/dps/models.py
@@ -1,4 +1,6 @@
 import uuid
+import json
+
 from datetime import datetime
 
 from django.db import models
@@ -69,6 +71,14 @@ class Transaction(models.Model):
         return bool(Transaction.objects.exclude(status=status)
                                        .filter(id=self.id)
                                        .update(status=status))
+
+    def get_result_dict(self):
+        return json.loads(self.result)
+
+    def set_result_dict(self, result_dict):
+        self.result = json.dumps(result_dict, indent=4, sort_keys=True)
+
+    result_dict = property(get_result_dict, set_result_dict)
 
     def save(self, **kwargs):
         if self.content_object and not self.amount:

--- a/dps/transactions.py
+++ b/dps/transactions.py
@@ -177,9 +177,9 @@ def make_payment(content_object, request=None, transaction_opts={}):
                                lambda *args: None)
         else:
             status_updated = trans.set_status(Transaction.FAILED)
-            callback = getattr(content_object, "transaction_failed", 
+            callback = getattr(content_object, "transaction_failed",
                                lambda *args: None)
-        trans.result = result
+        trans.result_dict = result
         trans.save()
         callback(trans, False, status_updated)
         return (success, trans)

--- a/dps/views.py
+++ b/dps/views.py
@@ -23,7 +23,7 @@ def transaction_success(request, token, result=None):
                                     status__in=[Transaction.PROCESSING,
                                                 Transaction.SUCCESSFUL],
                                     secret=token)
-    transaction.result = pformat(result, width=1)
+    transaction.result_dict = result
     transaction.save()
 
     status_updated = transaction.set_status(Transaction.SUCCESSFUL)
@@ -62,7 +62,7 @@ def transaction_failure(request, token, result=None):
                                     status__in=[Transaction.PROCESSING,
                                                 Transaction.FAILED],
                                     secret=token)
-    transaction.result = pformat(result, width=1)
+    transaction.result_dict = result
     transaction.save()
 
     status_updated = transaction.set_status(Transaction.FAILED)


### PR DESCRIPTION
The transaction result was stored as a Python style pretty-printed string in a text field. The data could be read by humans in the admin, but could not be accessed in code.

Instead, the result is now stored as pretty-printed JSON. It is still human readable, but now also accessible from code. A `Transaction.result_dict` property has been added that allows getting/setting the `result` attribute as a dict.
