### PR TITLE
Use `QuerySet.as_manager` instead of custom manager

### DIFF
--- a/dps/models.py
+++ b/dps/models.py
@@ -15,11 +15,10 @@ def make_uuid():
     return str(u).replace('-', '')
 
 
-class TransactionManager(models.Manager):
+class TransactionQuerySet(models.QuerySet):
     def for_object(self, obj):
         ctype = ContentType.objects.get_for_model(obj)
-        return self.get_query_set().filter(content_type=ctype,
-                                           object_id=obj.id)
+        return self.filter(content_type=ctype, object_id=obj.id)
 
 
 class Transaction(models.Model):
@@ -53,7 +52,7 @@ class Transaction(models.Model):
                               unique=True, db_index=True)
     result = models.TextField(blank=True)
 
-    objects = TransactionManager()
+    objects = TransactionQuerySet.as_manager()
 
     class Meta:
         ordering = ('-created', '-id')

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description=open(readme_path).read(),
 
     install_requires=[
-        'Django>=1.6',
+        'Django>=1.7',
     ],
 
     include_package_data=True,


### PR DESCRIPTION
The custom manager used the deprecated and removed `Manager.get_query_set` method, instead of the renamed `Manager.get_queryset` method. Instead of fixing this, I replaced it with a `QuerySet` which can call `.filter` directly, and used the newish `QuerySet.as_manager` classmethod to make the manager.

This requires dropping support for Django 1.6.
