### PR TITLE
Add tox.ini, initial Python3 support, flake8 style checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 MANIFEST
 *.egg-info/
 /tests/dps_settings.py
+.tox/

--- a/README.md
+++ b/README.md
@@ -62,3 +62,10 @@ Then, assuming virtualenvwrapper is installed:
     > pip install requests
     > ./setup.py install
     > ./runtests.py
+
+To run the tests across all supported Python and Django versions, use `tox`:
+
+    > cd path-to/django-dps
+    > mkvirtualenv test
+    > pip install tox
+    > tox

--- a/dps/__init__.py
+++ b/dps/__init__.py
@@ -1,1 +1,3 @@
 from ._version import __version__
+
+__all__ = ['__version__']

--- a/dps/models.py
+++ b/dps/models.py
@@ -6,13 +6,15 @@ from datetime import datetime
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.six import text_type
 
 
 def make_uuid():
     """the hyphens in uuids are unnecessary, and brevity will be an
     advantage in our urls."""
     u = uuid.uuid4()
-    return str(u).replace('-', '')
+    return text_type(u).replace('-', '')
 
 
 class TransactionQuerySet(models.QuerySet):
@@ -21,6 +23,7 @@ class TransactionQuerySet(models.QuerySet):
         return self.filter(content_type=ctype, object_id=obj.id)
 
 
+@python_2_unicode_compatible
 class Transaction(models.Model):
     PURCHASE = "Purchase"
     AUTH = "Auth"
@@ -57,7 +60,7 @@ class Transaction(models.Model):
     class Meta:
         ordering = ('-created', '-id')
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%s %s of $%.2f on %s" % (
                self.get_status_display(),
                self.get_transaction_type_display().lower(),
@@ -96,7 +99,7 @@ class Transaction(models.Model):
     @property
     def merchant_reference(self):
         # Seems to have an undocumented 50 char limit
-        return (u"(#%d) %s" % (self.pk, unicode(self.content_object)))[:50]
+        return (u"(#%d) %s" % (self.pk, text_type(self.content_object)))[:50]
 
     @property
     def transaction_id(self):

--- a/dps/models.py
+++ b/dps/models.py
@@ -62,9 +62,9 @@ class Transaction(models.Model):
 
     def __str__(self):
         return u"%s %s of $%.2f on %s" % (
-               self.get_status_display(),
-               self.get_transaction_type_display().lower(),
-               self.amount, unicode(self.created))
+            self.get_status_display(),
+            self.get_transaction_type_display().lower(),
+            self.amount, unicode(self.created))
 
     def set_status(self, status):
         '''Atomically set transaction status, returning True if the status was

--- a/dps/transactions.py
+++ b/dps/transactions.py
@@ -98,7 +98,7 @@ def get_interactive_result(result_key):
         output[key] = result.find(key).text
 
     output["valid"] = result.get("valid")
-    
+
     return output
 
 
@@ -115,7 +115,7 @@ def offline_payment(params):
     merged_params = {}
     merged_params.update(PXPOST_DEFAULTS)
     merged_params.update(params)
-    
+
     result = _get_response(PXPOST_URL,
                            _params_to_xml_doc(merged_params, root="Txn"))
 
@@ -132,14 +132,13 @@ def offline_payment(params):
         result = _get_response(PXPOST_URL,
                                _params_to_xml_doc(status_params, root="Txn"))
 
-        
     success = result.find(".//Authorized").text == "1"
     return (success, ElementTree.tostring(result))
 
 
 def make_payment(content_object, request=None, transaction_opts={}):
     """Main entry point. If we have a request we do it interactive, otherwise it's a batch/offline payment."""
-    
+
     trans = Transaction(content_object=content_object)
     trans.status = Transaction.PROCESSING
     trans.save()
@@ -164,7 +163,7 @@ def make_payment(content_object, request=None, transaction_opts={}):
         # set up for an offline/batch payment.
         params.update({"DpsBillingId": content_object.get_billing_token(),
                        "TxnId": trans.transaction_id})
-    
+
     params.update(transaction_opts)
 
     if request:

--- a/dps/transactions.py
+++ b/dps/transactions.py
@@ -1,8 +1,8 @@
-import urllib, urllib2
-
 from xml.etree import cElementTree as ElementTree
 from django.conf import settings
 from django.http import HttpResponseRedirect
+from django.utils.six import text_type
+from django.utils.six.moves.urllib.request import Request, urlopen
 
 from .models import Transaction
 
@@ -34,8 +34,8 @@ PXPOST_DEFAULTS = {
 
 def _get_response(url, xml_body):
     """Takes and returns an ElementTree xml document."""
-    req = urllib2.Request(url, ElementTree.tostring(xml_body, encoding='utf-8'))
-    response = urllib2.urlopen(req)
+    req = Request(url, ElementTree.tostring(xml_body, encoding='utf-8'))
+    response = urlopen(req)
     ret = ElementTree.fromstring(response.read())
     response.close()
     return ret
@@ -52,7 +52,7 @@ def _params_to_xml_doc(params, root="GenerateRequest"):
         if isinstance(value, Exception):
             raise value
         elem = ElementTree.Element(key)
-        elem.text = unicode(value)
+        elem.text = text_type(value)
         root_tag.append(elem)
 
     return root_tag
@@ -109,7 +109,7 @@ def offline_payment(params):
                 params.get("DpsBillingId", None) or
                 (params.get("CardNumber", None) and params.get("Cvc2", None)))
         assert params.get("TxnId", None)
-    except AssertionError, e:
+    except AssertionError as e:
         return (False, e)
 
     merged_params = {}

--- a/dps/views.py
+++ b/dps/views.py
@@ -1,7 +1,6 @@
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponseRedirect
 from django.http import HttpResponseForbidden
-from pprint import pformat
 from django.http import Http404
 from django.shortcuts import render_to_response
 
@@ -34,18 +33,17 @@ def transaction_success(request, token, result=None):
         content_object.set_billing_token(result["DpsBillingId"] or None)
 
     # callback, if it exists. It may optionally return a url for redirection
-    success_url = getattr(content_object,
-                          "transaction_succeeded",
-                          lambda *args: None)(transaction, True,
-                                              status_updated)
+    success_cb = getattr(content_object, "transaction_succeeded",
+                         lambda *args: None)
+    success_url = success_cb(transaction, True, status_updated)
 
     if success_url:
         # assumed to be a valid url
         return HttpResponseRedirect(success_url)
     else:
         return render_to_response("dps/transaction_success.html", {
-                    "request": request,
-                    "transaction": transaction})
+            "request": request,
+            "transaction": transaction})
 
 
 @dps_result_view
@@ -70,15 +68,14 @@ def transaction_failure(request, token, result=None):
     content_object = transaction.content_object
 
     # callback, if it exists. It may optionally return a url for redirection
-    failure_url = getattr(content_object,
-                          "transaction_failed",
-                          lambda *args: None)(transaction, True,
-                                              status_updated)
+    failure_cb = getattr(content_object, "transaction_failed",
+                         lambda *args: None)
+    failure_url = failure_cb(transaction, True, status_updated)
 
     if failure_url:
         # assumed to be a valid url
         return HttpResponseRedirect(failure_url)
     else:
         return render_to_response("dps/transaction_failure.html", {
-                "request": request,
-                "transaction": transaction})
+            "request": request,
+            "transaction": transaction})

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,7 @@
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME':  'test.sqlite',
+        'NAME': 'test.sqlite',
     }
 }
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,4 +15,4 @@ INSTALLED_APPS = [
 
 ROOT_URLCONF = "tests.urls"
 
-from dps_settings import *
+from .dps_settings import *

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,7 @@
 import requests
 
 from django.test import TestCase, RequestFactory
+from django.utils.six import text_type
 from dps.transactions import make_payment
 
 from .models import Payment
@@ -20,8 +21,8 @@ class DpsTestCase(TestCase):
         response = requests.get(response['Location'])
 
         # check the dps page looks approximately correct
-        self.assertIn('Payment Checkout', response.content)
-        self.assertIn(str(amount), response.content)
+        self.assertIn('Payment Checkout', response.text)
+        self.assertIn(text_type(amount), response.text)
 
     def test_recurring(self):
         pass

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,12 @@ skipsdist = True
 skip_missing_interpreters = True
 usedevelop = True
 
-envlist = py{27,33,34}-dj{17,18}
+envlist = py{27,33,34}-dj{17,18}, flake8
+
+[flake8]
+ignore = E501
+exclude = dps/migrations/*
+exclude = dps/south_migrations/*
 
 [testenv]
 basepython =
@@ -16,3 +21,8 @@ deps =
 
     dj17: Django>=1.7.1,<1.8
     dj18: Django>=1.8,<1.9
+
+[testenv:flake8]
+basepython=python3.4
+deps=flake8>=2.2.0
+commands=flake8 dps

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+usedevelop = True
+
+envlist = py{27,33,34}-dj{17,18}
+
+[testenv]
+basepython =
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+
+deps =
+    requests==2.7.0
+
+    dj17: Django>=1.7.1,<1.8
+    dj18: Django>=1.8,<1.9


### PR DESCRIPTION
Each commit describes what I did in more detail, but:
- Add initial support for Python 3 - the test passes in Python 3 now
- Add `tox` config for running the tests against Django 1.7, 1.8, Python 2.7, 3.3, 3.4
- Add `flake8` test for checking code style and cleanliness across the whole project
- Fix up issues found by `flake8`
